### PR TITLE
Add title for sidebars metabox

### DIFF
--- a/class-fw-extension-sidebars.php
+++ b/class-fw-extension-sidebars.php
@@ -93,7 +93,7 @@ class FW_Extension_Sidebars extends FW_Extension {
 		if($this->get_config('show_in_post_types') === true) {
 			return array_merge($options, array(
 				'sidebar-picker' => array(
-					'title'   => false,
+					'title'   => 'Sidebar Picker',
 					'type'    => 'box',
 					'context' => 'side',
 					'options' => array(

--- a/class-fw-extension-sidebars.php
+++ b/class-fw-extension-sidebars.php
@@ -93,7 +93,7 @@ class FW_Extension_Sidebars extends FW_Extension {
 		if($this->get_config('show_in_post_types') === true) {
 			return array_merge($options, array(
 				'sidebar-picker' => array(
-					'title'   => 'Sidebar Picker',
+					'title'   => __('Sidebar Picker', 'fw'),
 					'type'    => 'box',
 					'context' => 'side',
 					'options' => array(


### PR DESCRIPTION
This will fix checkbox from **Screen Options** being without label.

![add_new_page_ _asd_ _wordpress_and_wunderlist](https://cloud.githubusercontent.com/assets/2979628/14673419/89d5c554-0706-11e6-800f-824d8a07cc36.png)
