### PR TITLE
Get count of sidebars from config.

### DIFF
--- a/includes/class-fw-extension-sidebars-backend.php
+++ b/includes/class-fw-extension-sidebars-backend.php
@@ -824,7 +824,24 @@ class _FW_Extension_Sidebars_Backend {
 			return $result;
 		}
 
-		return _FW_Extension_Sidebars_Config::$allowed_colors;
+		$positions = $this->config->get_sidebar_positions();
+		$colors = _FW_Extension_Sidebars_Config::$allowed_colors;
+		
+		$max = 1;
+		if( count( $positions ) && is_array( $positions ) ) {
+			foreach( $positions as $key => $sidebar ) {
+				$count = fw_akg( _FW_Extension_Sidebars_Config::SIDEBARS_NR_KEY, $sidebar );
+				if( $count > $max ) {
+					$max = $count;
+				}
+			}
+		}
+		
+		if( $max > count( $colors ) ) {
+			return $colors;
+		} else {
+			return array_slice( $colors, 0, $max );
+		}
 	}
 
 


### PR DESCRIPTION
In Post Editor we always have a static number of 4 sidebars, even if in our extensions/sidebars/config.php `sidebars_number` is less than 4.
![Image](https://i.gyazo.com/20a4357ca56378ed52a42c3db07ea31e.png)

Now, count of avaible sidebars is equal to `sidebars_number` from config.
![Image2](https://i.gyazo.com/227eae271a6ef934c08e0a99bebed22b.png)

``` php
$cfg['sidebar_positions'] = array(
    'full' => array(
        'icon_url' => 'full.png',
        'sidebars_number' => 0,
    ),

    'left' => array(
        'icon_url' => 'left.png',
        'sidebars_number' => 1,
    ),

    'right' => array(
        'icon_url' => 'right.png',
        'sidebars_number' => 1,
    ),

    'left_right' => array(
        'icon_url' => 'left_right.png',
        'sidebars_number' => 2,
    ),

);
```
